### PR TITLE
Swapchain: don't wrap in Arc 

### DIFF
--- a/src/gpu/buffer.rs
+++ b/src/gpu/buffer.rs
@@ -10,7 +10,7 @@ pub struct Buffer {
 }
 
 impl Buffer {
-    pub fn new(device: &Arc<Device>, size: usize, usage: vk::BufferUsageFlags) -> Self {
+    pub fn new(device: Arc<Device>, size: usize, usage: vk::BufferUsageFlags) -> Self {
         let create_info = vk::BufferCreateInfo {
             s_type: vk::StructureType::BUFFER_CREATE_INFO,
             p_next: std::ptr::null(),
@@ -30,7 +30,7 @@ impl Buffer {
         };
 
         Self {
-            device: device.clone(),
+            device: device,
             vk_buffer,
             vk_memory: None,
         }

--- a/src/gpu/command_buffer.rs
+++ b/src/gpu/command_buffer.rs
@@ -11,7 +11,7 @@ pub struct CommandPool {
 
 impl CommandPool {
     pub fn new(
-        device: &Arc<Device>,
+        device: Arc<Device>,
         queue_family: &QueueFamily,
         flags: vk::CommandPoolCreateFlags,
     ) -> Rc<Self> {
@@ -30,7 +30,7 @@ impl CommandPool {
         };
 
         Rc::new(Self {
-            device: device.clone(),
+            device: device,
             vk_command_pool,
         })
     }

--- a/src/gpu/command_buffer.rs
+++ b/src/gpu/command_buffer.rs
@@ -59,7 +59,7 @@ impl CommandPool {
                 .unwrap()[0]
         };
 
-        CommandBuffer::new(self, vk_command_buffer)
+        CommandBuffer::new(self.clone(), vk_command_buffer)
     }
 }
 
@@ -85,9 +85,9 @@ pub struct CommandBuffer {
 }
 
 impl CommandBuffer {
-    pub fn new(pool: &Rc<CommandPool>, vk_command_buffer: vk::CommandBuffer) -> Self {
+    pub fn new(pool: Rc<CommandPool>, vk_command_buffer: vk::CommandBuffer) -> Self {
         Self {
-            pool: pool.clone(),
+            pool,
             vk_command_buffer,
         }
     }
@@ -150,10 +150,9 @@ impl CommandBuffer {
         }
     }
 
-    pub fn bind_pipeline(
-        &self,
-        pipeline: &Arc<impl Pipeline + HasRawVkHandle<vk::Pipeline>>,
-    ) -> () {
+    pub fn bind_pipeline<T>(&self, pipeline: &T) -> ()
+        where T:  Pipeline + HasRawVkHandle<vk::Pipeline>
+    {
         unsafe {
             self.pool.device.get_ash_handle().cmd_bind_pipeline(
                 self.vk_command_buffer,

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -15,8 +15,8 @@ impl Device {
     pub fn new(
         gpu_phy_device: &Arc<PhysicalDevice>,
         vk_phy_device: vk::PhysicalDevice,
-        queue_family_indices: &Vec<u32>,
-        enabled_extensions: &Vec<String>,
+        queue_family_indices: &[u32],
+        enabled_extensions: &[&str],
     ) -> Arc<Device> {
         // Get the filtered list of queue families
         let queue_family_properties = gpu_phy_device.get_queue_family_properties();
@@ -33,8 +33,8 @@ impl Device {
         }
 
         let enabled_extensions_cstrs = enabled_extensions
-            .into_iter()
-            .map(|x| CString::new(x.clone()).unwrap())
+            .iter()
+            .map(|x| CString::new(Vec::from(x.as_bytes())).unwrap())
             .collect::<Vec<_>>();
 
         let enabled_extensions_ptrs = enabled_extensions_cstrs
@@ -175,14 +175,10 @@ pub struct QueueFamilyConfig {
 
 impl QueueFamilyConfig {
     pub fn new(index: u32, properties: vk::QueueFamilyProperties) -> QueueFamilyConfig {
-        let mut priorities: Vec<f32> = vec![];
-        for _ in 0..properties.queue_count {
-            priorities.push(1.0);
-        }
         QueueFamilyConfig {
             index,
             properties,
-            priorities,
+            priorities: vec![1.0; properties.queue_count as usize],
         }
     }
 
@@ -226,7 +222,7 @@ impl QueueFamily {
         &self.config.properties
     }
 
-    pub fn priorities(&self) -> &Vec<f32> {
+    pub fn priorities(&self) -> &[f32] {
         &self.config.priorities
     }
 
@@ -247,7 +243,7 @@ impl QueueFamily {
                     .get_ash_handle()
                     .get_device_queue(family_index, index)
             };
-            Queue::new(&device_arc, family_index, vk_queue, index)
+            Queue::new(device_arc, family_index, vk_queue, index)
         })
     }
 }

--- a/src/gpu/device.rs
+++ b/src/gpu/device.rs
@@ -105,17 +105,17 @@ impl Device {
 
     // TODO
     pub fn get_swapchain(
-        self: &Arc<Device>,
+        self: Arc<Device>,
         min_image_count: u32,
         image_format: vk::Format,
         image_color_space: vk::ColorSpaceKHR,
         image_extent: vk::Extent2D,
         image_usage: vk::ImageUsageFlags,
         present_mode: vk::PresentModeKHR,
-        old_swapchain: Option<&Arc<Swapchain>>,
-    ) -> Arc<Swapchain> {
+        old_swapchain: Option<&Swapchain>,
+    ) -> Swapchain {
         Swapchain::new(
-            self,
+            self.clone(),
             min_image_count,
             image_format,
             image_color_space,

--- a/src/gpu/graphics_pipeline.rs
+++ b/src/gpu/graphics_pipeline.rs
@@ -13,7 +13,7 @@ pub trait Pipeline {
 
 impl GraphicsPipeline {
     pub fn new(
-        device: &Arc<Device>,
+        device: Arc<Device>,
         shader_modules: &[Arc<ShaderModule>],
         vertex_bindings: Option<&[vk::VertexInputBindingDescription]>,
         vertex_attributes: Option<&[vk::VertexInputAttributeDescription]>,
@@ -22,8 +22,8 @@ impl GraphicsPipeline {
         primitive_restart: bool,
         _viewports: Option<&[vk::Viewport]>,
         _scissors: Option<&[vk::Rect2D]>,
-        pipeline_layout: &Arc<PipelineLayout>,
-        render_pass: &Arc<RenderPass>,
+        pipeline_layout: &PipelineLayout,
+        render_pass: &RenderPass,
     ) -> Arc<GraphicsPipeline> {
         let mut create_info = unsafe {
             vk::GraphicsPipelineCreateInfo {
@@ -229,7 +229,7 @@ impl GraphicsPipeline {
         };
 
         Arc::new(GraphicsPipeline {
-            device: device.clone(),
+            device,
             vk_pipeline,
         })
     }

--- a/src/gpu/graphics_pipeline.rs
+++ b/src/gpu/graphics_pipeline.rs
@@ -14,14 +14,14 @@ pub trait Pipeline {
 impl GraphicsPipeline {
     pub fn new(
         device: &Arc<Device>,
-        shader_modules: &Vec<Arc<ShaderModule>>,
+        shader_modules: &[Arc<ShaderModule>],
         vertex_bindings: Option<&[vk::VertexInputBindingDescription]>,
         vertex_attributes: Option<&[vk::VertexInputAttributeDescription]>,
-        dynamic_states: &Vec<vk::DynamicState>,
+        dynamic_states: &[vk::DynamicState],
         topology: vk::PrimitiveTopology,
         primitive_restart: bool,
-        _viewports: Option<&Vec<vk::Viewport>>,
-        _scissors: Option<&Vec<vk::Rect2D>>,
+        _viewports: Option<&[vk::Viewport]>,
+        _scissors: Option<&[vk::Rect2D]>,
         pipeline_layout: &Arc<PipelineLayout>,
         render_pass: &Arc<RenderPass>,
     ) -> Arc<GraphicsPipeline> {

--- a/src/gpu/instance.rs
+++ b/src/gpu/instance.rs
@@ -90,7 +90,7 @@ impl Instance {
         &self.surface
     }
 
-    fn _get_physical_device_handles(&self) -> &Vec<vk::PhysicalDevice> {
+    fn _get_physical_device_handles(&self) -> &[vk::PhysicalDevice] {
         self.vk_physical_devices
             .get_or_init(|| unsafe { self.ash_instance.enumerate_physical_devices().unwrap() })
     }
@@ -98,7 +98,7 @@ impl Instance {
     pub fn get_physical_devices(self: &Arc<Instance>) -> Vec<Arc<PhysicalDevice>> {
         self._get_physical_device_handles()
             .iter()
-            .map(|vk_phy_device| PhysicalDevice::new(*vk_phy_device, self))
+            .map(|vk_phy_device| PhysicalDevice::new(*vk_phy_device, self.clone()))
             .collect()
     }
 }

--- a/src/gpu/physical_device.rs
+++ b/src/gpu/physical_device.rs
@@ -19,10 +19,10 @@ pub struct PhysicalDevice {
 impl PhysicalDevice {
     pub fn new(
         vk_phy_device: vk::PhysicalDevice,
-        gpu_instance: &Arc<Instance>,
+        gpu_instance: Arc<Instance>,
     ) -> Arc<PhysicalDevice> {
         Arc::new(PhysicalDevice {
-            gpu_instance: gpu_instance.clone(),
+            gpu_instance: gpu_instance,
             vk_phy_device,
             properties: OnceCell::new(),
             extension_properties: OnceCell::new(),
@@ -36,8 +36,8 @@ impl PhysicalDevice {
 
     pub fn get_device(
         self: &Arc<PhysicalDevice>,
-        queue_family_indices: &Vec<u32>,
-        enabled_extensions: &Vec<String>,
+        queue_family_indices: &[u32],
+        enabled_extensions: &[&str],
     ) -> Arc<Device> {
         Device::new(
             self,
@@ -55,7 +55,7 @@ impl PhysicalDevice {
         })
     }
 
-    fn _get_device_extension_properties(&self) -> &Vec<vk::ExtensionProperties> {
+    fn _get_device_extension_properties(&self) -> &[vk::ExtensionProperties] {
         self.extension_properties.get_or_init(|| unsafe {
             self.gpu_instance
                 .get_ash_handle()
@@ -80,7 +80,7 @@ impl PhysicalDevice {
         self._get_physical_device_properties().device_type
     }
 
-    pub fn extension_names(&self) -> &Vec<String> {
+    pub fn extension_names(&self) -> &[String] {
         self.extension_names.get_or_init(|| {
             let mut extension_names = vec![];
             for x in self._get_device_extension_properties() {
@@ -90,8 +90,8 @@ impl PhysicalDevice {
         })
     }
 
-    pub fn extension_name_hashset(&self) -> HashSet<&String> {
-        HashSet::from_iter(self.extension_names())
+    pub fn extension_name_hashset(&self) -> HashSet<&str> {
+        HashSet::from_iter(self.extension_names().iter().map(String::as_str))
     }
 
     pub fn get_queue_family_properties(&self) -> Vec<vk::QueueFamilyProperties> {

--- a/src/gpu/pipeline_layout.rs
+++ b/src/gpu/pipeline_layout.rs
@@ -10,8 +10,8 @@ pub struct PipelineLayout {
 impl PipelineLayout {
     pub fn new(
         device: &Arc<Device>,
-        descriptor_set_layouts: Option<&Vec<()>>,
-        push_constant_ranges: Option<&Vec<vk::PushConstantRange>>,
+        descriptor_set_layouts: Option<&[()]>,
+        push_constant_ranges: Option<&[vk::PushConstantRange]>,
     ) -> Arc<PipelineLayout> {
         let mut pipeline_layout_create_info = vk::PipelineLayoutCreateInfo {
             s_type: vk::StructureType::PIPELINE_LAYOUT_CREATE_INFO,

--- a/src/gpu/queue.rs
+++ b/src/gpu/queue.rs
@@ -12,13 +12,13 @@ pub struct Queue {
 
 impl Queue {
     pub fn new(
-        device: &Arc<Device>,
+        device: Arc<Device>,
         family_index: u32,
         vk_queue: vk::Queue,
         index: u32,
     ) -> Arc<Queue> {
         Arc::new(Queue {
-            device: device.clone(),
+            device,
             family_index,
             vk_queue,
             index,

--- a/src/gpu/shader_module.rs
+++ b/src/gpu/shader_module.rs
@@ -20,7 +20,7 @@ pub struct ShaderModule {
 
 impl ShaderModule {
     pub fn new(
-        device: &Arc<Device>,
+        device: Arc<Device>,
         compiler: &shaderc::Compiler,
         source: &str,
         kind: ShaderKind,
@@ -55,7 +55,7 @@ impl ShaderModule {
         };
 
         Arc::new(ShaderModule {
-            device: device.clone(),
+            device,
             vk_shader_module,
             kind,
             entry_point,

--- a/src/gpu/swapchain.rs
+++ b/src/gpu/swapchain.rs
@@ -93,7 +93,7 @@ impl Swapchain {
         &self.extent
     }
 
-    pub fn images(&self) -> &Vec<Arc<Image>> {
+    pub fn images(&self) -> &[Arc<Image>] {
         self.images.get_or_init(|| unsafe {
             self.ash_swapchain_fn
                 .get_swapchain_images(self.vk_swapchain)

--- a/src/gpu/swapchain.rs
+++ b/src/gpu/swapchain.rs
@@ -13,15 +13,15 @@ pub struct Swapchain {
 
 impl Swapchain {
     pub fn new(
-        gpu_device: &Arc<Device>,
+        gpu_device: Arc<Device>,
         min_image_count: u32,
         image_format: vk::Format,
         image_color_space: vk::ColorSpaceKHR,
         image_extent: vk::Extent2D,
         image_usage: vk::ImageUsageFlags,
         present_mode: vk::PresentModeKHR,
-        old_swapchain: Option<&Arc<Swapchain>>,
-    ) -> Arc<Swapchain> {
+        old_swapchain: Option<&Swapchain>,
+    ) -> Swapchain {
         // TODO: Assumes that graphics and presentation queues are the same,
         // which will usually be the case. Should check if they're different and
         // use `vk::SharingMode::CONCURRENT` and pass in `pQueueFamilyIndices`
@@ -71,14 +71,14 @@ impl Swapchain {
                 .expect("failed to create swapchain")
         };
 
-        Arc::new(Swapchain {
-            gpu_device: gpu_device.clone(),
+        Swapchain {
+            gpu_device,
             vk_swapchain,
             ash_swapchain_fn,
             format: image_format,
             extent: image_extent,
             images: OnceCell::new(),
-        })
+        }
     }
 
     pub fn device(&self) -> &Arc<Device> {

--- a/src/gpu/sync.rs
+++ b/src/gpu/sync.rs
@@ -8,7 +8,7 @@ pub struct Semaphore {
 }
 
 impl Semaphore {
-    pub fn new(device: &Arc<Device>) -> Self {
+    pub fn new(device: Arc<Device>) -> Self {
         let vk_semaphore = unsafe {
             device
                 .get_ash_handle()
@@ -16,7 +16,7 @@ impl Semaphore {
                 .expect("failed to create semaphore")
         };
         Self {
-            device: device.clone(),
+            device,
             vk_semaphore,
         }
     }
@@ -44,7 +44,7 @@ pub struct Fence {
 }
 
 impl Fence {
-    pub fn new(device: &Arc<Device>) -> Self {
+    pub fn new(device: Arc<Device>) -> Self {
         let vk_fence = unsafe {
             device
                 .get_ash_handle()
@@ -52,12 +52,12 @@ impl Fence {
                 .expect("failed to create fence")
         };
         Self {
-            device: device.clone(),
+            device,
             vk_fence,
         }
     }
 
-    pub fn signaled(device: &Arc<Device>) -> Self {
+    pub fn signaled(device: Arc<Device>) -> Self {
         let vk_fence = unsafe {
             device
                 .get_ash_handle()
@@ -71,7 +71,7 @@ impl Fence {
                 .expect("failed to create fence")
         };
         Self {
-            device: device.clone(),
+            device,
             vk_fence,
         }
     }

--- a/src/render_context.rs
+++ b/src/render_context.rs
@@ -44,9 +44,9 @@ impl RenderContext {
 
         let required_queue_flags = vec![vk::QueueFlags::GRAPHICS];
 
-        let required_extensions: Vec<String> = vec![
-            // String::from("VK_EXT_debug_utils"),
-            String::from("VK_KHR_swapchain"),
+        let required_extensions = &[
+            // "VK_EXT_debug_utils",
+            "VK_KHR_swapchain",
         ];
 
         // Find the first physical device that supports the swapchain extension
@@ -77,12 +77,7 @@ impl RenderContext {
                 // Filter for physical devices that support all of the required
                 // extensions
                 let extensions_hashset = x.extension_name_hashset();
-                for x in &required_extensions {
-                    if !extensions_hashset.contains(x) {
-                        return false;
-                    }
-                }
-                true
+                required_extensions.iter().all(|ext| extensions_hashset.contains(ext))
             })
             .unwrap();
 
@@ -116,7 +111,7 @@ impl RenderContext {
             }
         }
 
-        let device = physical_device.get_device(&queue_family_indices, &required_extensions);
+        let device = physical_device.get_device(&queue_family_indices, required_extensions);
 
         let swapchain = {
             let inner_size = window.inner_size();
@@ -608,7 +603,7 @@ impl RenderFrame {
             vk::SubpassContents::INLINE,
         );
 
-        self.cmd_buf.bind_pipeline(&context.graphics_pipeline);
+        self.cmd_buf.bind_pipeline(context.graphics_pipeline.as_ref());
 
         self.cmd_buf.set_viewport(
             0,


### PR DESCRIPTION
Mostly going on idea that `&Arc<T>` should generally be avoided in signatures,
if you're going to clone it, take `Arc<T>` & let caller clone it (or move it),
if you're not going to clone it, take `&T`

But getting the feeling these should all be passed around by reference,
their lifetime determined by the RenderContext holding them,
maybe even using typed arena: https://docs.rs/typed-arena/latest/typed_arena

Decided to demo the idea on Swapchain,
but same should be doable with Device

Built on top of #1